### PR TITLE
Added jacoco plugin and ignores

### DIFF
--- a/SurveyService/.gitignore
+++ b/SurveyService/.gitignore
@@ -31,5 +31,10 @@ build/
 .vscode/
 
 ### Other ###
-/sync-errors.html
 /Dockerfile
+
+### Jacoco Files ###
+/report
+
+### Local Error Report ###
+sync-errors.html

--- a/SurveyService/pom.xml
+++ b/SurveyService/pom.xml
@@ -139,6 +139,28 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+
+			<!-- Plugin for running jacoco when executing Maven Test -->
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.5</version>
+				<executions>
+					<execution>
+						<id>default-prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>default-report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
The plugin is all the repository needs to generate a jacoco.exec file. I will be adding documentation to instruct future developers on what other files they will need, to have Jacoco reports generated on their local system off of the exec file.